### PR TITLE
Fix issue where adjacent comments were skipped during canonicalization

### DIFF
--- a/exclusivecanonicalization.go
+++ b/exclusivecanonicalization.go
@@ -148,11 +148,14 @@ func (e ExclusiveCanonicalization) processRecursive(node *etree.Element,
 	newDefaultNS, newPrefixesInScope :=
 		e.renderAttributes(node, prefixesInScope, defaultNS)
 
-	for _, child := range node.Child {
+	for i := 0; i < len(node.Child); i++ {
+		child := node.Child[i]
+
 		switch child := child.(type) {
 		case *etree.Comment:
 			if !e.WithComments {
 				removeTokenFromElement(etree.Token(child), node)
+				i--
 			}
 		case *etree.Element:
 			e.processRecursive(child, newPrefixesInScope, newDefaultNS)


### PR DESCRIPTION
This is a cherry-pick from pull request from upstream: https://github.com/moov-io/signedxml/pull/51

There is a test case on that PR, but that test file doesn't exist on this fork, so I removed it during cherry-pick.

We might want to bring this fork up to date.

---

Addresses issue #50

If comments were adjacent in a document with no whitespace between them, then for each pair of comments the second comment would be skipped due to the underlying slice being modified as it was being ranged over.

For example, the following document:

```xml
<a><!-- comment1 --><!-- comment2 --><!-- comment 3 --></a>
```

Would be incorrectly canonicalized to:

```xml
<a><!-- comment2 --></a>
```

This patch fixes that issue and adds a new test case to cover it.
